### PR TITLE
Move how to Install to the front of how to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Extension to output the list of annotations from the recently executed Workflow in the current repository.
 
+## Install
+
+```shell
+gh extension install swfz/gh-annotations
+```
+
 ## Usage
 
 ```shell
@@ -51,12 +57,6 @@ $ gh annotations -json | jq
     "message": "Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout"
   }
 ]
-```
-
-## Install
-
-```shell
-gh extension install swfz/gh-annotations
 ```
 
 ## test

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ gh annotations
 $ gh annotations --help
   -repo string
         Optional Repository Name eg) owner/repo
-  -json bool 
+  -json bool
         Output JSON Format
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ Extension to output the list of annotations from the recently executed Workflow 
 ## Install
 
 ```shell
-gh extension install swfz/gh-annotations
+$ gh extension install swfz/gh-annotations
 ```
 
 ## Usage
 
 ```shell
-gh annotations
+$ gh annotations
 ```
 
 ### Optional Args
@@ -62,5 +62,5 @@ $ gh annotations -json | jq
 ## test
 
 ```shell
-go test -v
+$ go test -v
 ```


### PR DESCRIPTION
Move how to Install to the front of how to use.
One can now understand the installation and usage at a glance.