### PR TITLE
[proposal] Print a helpful suggestion for wrong argument

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cli/go-gh/pkg/term"
 	"io"
 	"log"
+	"os"
 	"strconv"
 )
 
@@ -283,6 +284,14 @@ func main() {
 	flag.StringVar(&options.repo, "repo", "", "Repository Name eg) owner/repo")
 	flag.BoolVar(&options.json, "json", false, "Output JSON")
 	flag.Parse()
+
+	arg := flag.Arg(0)
+
+	if arg != "" {
+		fmt.Println("Did you mean this?")
+		fmt.Printf("\tgh annotations -repo %s\n", arg)
+		os.Exit(1)
+	}
 
 	run(options)
 }


### PR DESCRIPTION
I didn't get the expected behavior.

```bash
$ gh annotations ytkg/takagi-dev
Repository  Workflow  Event  Job  JobStartedAt  JobCompletedAt  Conclusion  AnnotationLevel  Message
```

Because, I forgot to include the '-repo' option.
```bash
$ gh annotations -repo ytkg/takagi-dev
Repository       Workflow  Event  Job     JobStartedAt          JobCompletedAt        Conclusion  AnnotationLevel  Message
ytkg/takagi-dev  Deploy    push   Deploy  2023-05-06T14:49:24Z  2023-05-06T14:51:11Z  success     warning          Node.js 12 actions are deprecate...
```

So I tried to make it possible to notice the mistakenly entered argument.
I'm not proficient in the Go language. Please let me know if there is a better way to do it.

```bash
$ gh annotations ytkg/takagi-dev
Did you mean this?
        gh annotations -repo ytkg/takagi-dev
```