### PR TITLE
chore(deps): update go module directive to v1.26.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/swfz/gh-annotations
 
-go 1.26.1
+go 1.26.3
 
 toolchain go1.26.3
 


### PR DESCRIPTION
## Summary
- Update go directive from 1.26.1 to 1.26.3 to match the toolchain version
- Originally from Renovate PR #93 which was auto-closed after conflict with #94

https://claude.ai/code/session_01Gzhdr2JAoVYMakbC4E2FG3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gzhdr2JAoVYMakbC4E2FG3)_